### PR TITLE
small restructuring for idiomatic layout of gem

### DIFF
--- a/docs/correlating-traces-and-logs.md
+++ b/docs/correlating-traces-and-logs.md
@@ -8,7 +8,7 @@ To add trace metadata of the current trace to logs, use the
 to set the formatter, as in the following example:
 
 ``` ruby
-require "splunk/otel/logging"
+require "splunk/otel"
 
 logger.formatter = proc do |severity, datetime, progname, msg|  
   "#{Splunk::Otel::Logging.format_correlation} : #{msg}\n"

--- a/lib/splunk/otel.rb
+++ b/lib/splunk/otel.rb
@@ -10,6 +10,41 @@ module Splunk
     # this allows the user to rescue a generic exception type to catch all exceptions
     class Error < StandardError; end
 
+    # Configures the OpenTelemetry SDK and instrumentation with Splunk defaults.
+    #
+    # @yieldparam [Configurator] configurator Yields a configurator to the
+    #   provided block
+    #
+    # Example usage:
+    #   Without a block defaults are installed without any instrumentation
+    #
+    #     Splunk::Otel.configure
+    #
+    #   Install instrumentation individually with optional config
+    #
+    #     Splunk::Otel.configure do |c|
+    #       c.use 'OpenTelemetry::Instrumentation::Faraday', tracer_middleware: SomeMiddleware
+    #     end
+    #
+    #   Install all instrumentation with optional config
+    #
+    #     Splunk::Otel.configure do |c|
+    #       c.use_all 'OpenTelemetry::Instrumentation::Faraday' => { tracer_middleware: SomeMiddleware }
+    #     end
+    #
+    #   Add a span processor
+    #
+    #     Splunk::Otel.configure do |c|
+    #       c.add_span_processor SpanProcessor.new(SomeExporter.new)
+    #     end
+    #
+    #   Configure everything
+    #
+    #     Splunk::Otel.configure do |c|
+    #       c.logger = Logger.new(File::NULL)
+    #       c.add_span_processor SpanProcessor.new(SomeExporter.new)
+    #       c.use_all
+    #     end
     def configure(service_name: ENV.fetch("OTEL_SERVICE_NAME", "unnamed-ruby-service"),
                   auto_instrument: false)
       set_default_propagators
@@ -126,3 +161,5 @@ module Splunk
                     :set_default_span_limits, :set_access_token_header, :set_endpoint
   end
 end
+
+require "splunk/otel/logging"

--- a/test/splunk/logging_test.rb
+++ b/test/splunk/logging_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 require "opentelemetry/sdk"
-require "splunk/otel/logging"
+require "splunk/otel"
 
 module Splunk
   class LoggingTest < Test::Unit::TestCase

--- a/test/splunk/otel_test.rb
+++ b/test/splunk/otel_test.rb
@@ -4,7 +4,6 @@ require "test_helper"
 require "splunk/otel"
 require "opentelemetry/sdk"
 require "opentelemetry/exporter/otlp"
-require "splunk/otel/logging"
 
 module Splunk
   class OtelTest < Test::Unit::TestCase


### PR DESCRIPTION
Includes adding: require "splunk/otel/logging" to the file
splunk/otel.rb so any time the formatting function is needed
the user only has to require "splunk/otel"