### PR TITLE
update release notes and remove use of gh cli in release script

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,5 +15,5 @@ both create a draft Github Release and push a Gem.
 - Once PR is approved and merged created a tag with the same version as
   `version.rb` prefixed with `v` and push the tag
 - Watch Gitlab CI for the `release` job to complete
-- Update the newly created Github Release notes with the contents of
+- Back on Github create a release from the pushed tag with the contents of
   `CHANGELOG.md`

--- a/scripts/install-release-deps.sh
+++ b/scripts/install-release-deps.sh
@@ -9,10 +9,3 @@ apt-get -y install \
   curl="7.74.0-1.3+deb11u3" \
   gnupg="2.2.27-2+deb11u2" \
   lsb-release="11.1.0" \
-
-# instructions from https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-apt
-curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-
-apt-get update
-apt-get -y install gh

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,18 +23,7 @@ release_tag="$1"
 # without the starting 'v'
 release_version=$(echo "$release_tag" | cut -c2-)
 
-create_gh_release() {
-  echo ">>> Creating GitHub release $release_tag ..."
-  gh release create "$release_tag" \
-    --repo "signalfx/splunk-otel-ruby" \
-    --draft \
-    --title "Release $release_tag"
-}
-
 # the gem publish for the tag is the most important so do that first
 bundle install
 bundle exec rake build
 bundle exec gem push pkg/splunk-otel-${release_version}.gem
-
-create_gh_release
-


### PR DESCRIPTION
Installing `gh` caused the first issue with releasing and then the second was that `gh` create release fails. I think we should just include this update to the releasing docs and remove it entirely.