### PR TITLE
chore: refresh OTel dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,7 @@ jobs:
         rubygems: [
           { ruby: "3.2", appraisal: "rails-7.0" },
           { ruby: "3.1", appraisal: "rails-7.0" },
-          { ruby: "3.0", appraisal: "rails-7.0" },
-          { ruby: "2.7", appraisal: "rails-7.0" },
-          { ruby: "2.7", appraisal: "rails-6.1" },
-          { ruby: "2.6", appraisal: "rails-6.1" }
+          { ruby: "3.0", appraisal: "rails-7.0" }
         ]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Apply RubyGems fixes
         run: gem update --system
       - name: Ensure we have modern bundler
-        run: gem install bundler -v '~> 2.3.26'
+        run: gem install bundler -v '~> 2.3.40'
       - name: Install dependencies
         run: bundle _2.3.26_
       - name: Verify nokogiri

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Apply RubyGems fixes
         run: gem update --system
       - name: Ensure we have modern bundler
-        run: gem install bundler -v '~> 2.4.20'
+        run: gem install bundler -v '2.4.21'
       - name: Install dependencies
-        run: bundle _2.4.20_
+        run: bundle _2.4.21_
       - name: Verify nokogiri
         run: bundle exec nokogiri -v
       - name: Install appraisal dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Apply RubyGems fixes
         run: gem update --system
       - name: Ensure we have modern bundler
-        run: gem install bundler -v '~> 2.3.40'
+        run: gem install bundler -v '~> 2.4.20'
       - name: Install dependencies
         run: bundle _2.3.26_
       - name: Verify nokogiri

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Ensure we have modern bundler
         run: gem install bundler -v '~> 2.4.20'
       - name: Install dependencies
-        run: bundle _2.3.26_
+        run: bundle _2.4.20_
       - name: Verify nokogiri
         run: bundle exec nokogiri -v
       - name: Install appraisal dependencies

--- a/examples/basic/console.rb
+++ b/examples/basic/console.rb
@@ -7,12 +7,10 @@ gemfile do
   source "https://rubygems.org"
 
   gem "splunk-otel", path: "../../"
-  gem "opentelemetry-exporter-otlp", "~> 0.21.0"
 end
 
 require "splunk/otel"
 require "splunk/otel/logging"
-require "opentelemetry/exporter/otlp"
 require "net/http"
 require "json"
 

--- a/examples/rails-7-barebones/Gemfile
+++ b/examples/rails-7-barebones/Gemfile
@@ -10,7 +10,7 @@ gem "puma"
 gem "rails", "~> 7.0.3"
 
 # instrumentation
-gem "opentelemetry-instrumentation-rails", "~> 0.22.0"
+gem "opentelemetry-instrumentation-rails", "~> 0.50.1"
 gem "splunk-otel", path: ENV.fetch("SPLUNK_OTEL_LOCATION", "../../")
 
 # tests

--- a/examples/rails-7-barebones/Gemfile
+++ b/examples/rails-7-barebones/Gemfile
@@ -10,7 +10,7 @@ gem "puma"
 gem "rails", "~> 7.0.3"
 
 # instrumentation
-gem "opentelemetry-instrumentation-rails", "~> 0.50.1"
+gem "opentelemetry-instrumentation-rails", "~> 0.28.1"
 gem "splunk-otel", path: ENV.fetch("SPLUNK_OTEL_LOCATION", "../../")
 
 # tests

--- a/splunk-otel.gemspec
+++ b/splunk-otel.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   # development tooling
   spec.add_development_dependency "appraisal", "2.5.0"
-  spec.add_development_dependency "bundler", "2.4.20"
+  spec.add_development_dependency "bundler", "~> 2.4.21"
   spec.add_development_dependency "rake", "13.0.6"
   spec.add_development_dependency "rubocop", "1.50.2"
   spec.add_development_dependency "rubocop-rake", "0.6.0"

--- a/splunk-otel.gemspec
+++ b/splunk-otel.gemspec
@@ -25,17 +25,17 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "opentelemetry-api", "~> 1.0"
+  spec.add_dependency "opentelemetry-api", "~> 1.2"
 
-  spec.add_dependency "opentelemetry-exporter-jaeger", ">= 0.20.1", "< 0.24.0"
-  spec.add_dependency "opentelemetry-exporter-otlp", ">= 0.21", "< 0.27"
-  spec.add_dependency "opentelemetry-instrumentation-base", "~> 0.21"
-  spec.add_dependency "opentelemetry-propagator-b3", ">= 0.19.2", "< 0.22.0"
-  spec.add_dependency "opentelemetry-sdk", "~> 1.0"
+  spec.add_dependency "opentelemetry-exporter-jaeger", "~> 0.23.0"
+  spec.add_dependency "opentelemetry-exporter-otlp", "~> 0.26.1"
+  spec.add_dependency "opentelemetry-instrumentation-base", "~> 0.22.2"
+  spec.add_dependency "opentelemetry-propagator-b3", "~> 0.21.0"
+  spec.add_dependency "opentelemetry-sdk", "~> 1.3.0"
 
   # development tooling
   spec.add_development_dependency "appraisal", "2.5.0"
-  spec.add_development_dependency "bundler", "2.3.26"
+  spec.add_development_dependency "bundler", "2.4.20"
   spec.add_development_dependency "rake", "13.0.6"
   spec.add_development_dependency "rubocop", "1.50.2"
   spec.add_development_dependency "rubocop-rake", "0.6.0"
@@ -45,8 +45,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "tzinfo-data", "1.2023.3"
 
   # development dependencies for integration testing
-  spec.add_development_dependency "opentelemetry-instrumentation-action_pack", "~> 0.5.0"
-  spec.add_development_dependency "opentelemetry-instrumentation-rack", "~> 0.22.1"
+  spec.add_development_dependency "opentelemetry-instrumentation-action_pack", "~> 0.7.0"
+  spec.add_development_dependency "opentelemetry-instrumentation-rack", "~> 0.23.4"
   spec.add_development_dependency "rack", "~> 2.2"
   spec.add_development_dependency "rack-test", "~> 2.0"
   spec.add_development_dependency "rails"


### PR DESCRIPTION
Latest OTel only supports Ruby 3.x, think it's a good time to evaluate dropping support for 2.x.